### PR TITLE
Add "-t patch" for optional patch

### DIFF
--- a/src/RequestFeedback.cc
+++ b/src/RequestFeedback.cc
@@ -180,7 +180,7 @@ std::string SolverRequester::Feedback::asUserString( const SolverRequester::Opti
       const std::string & pname( pIdent( _objsel ) );
       return( str::Format(_("Patch '%1%' is optional. Use '%2%' to install it, or '%3%' to include all optional patches."))
 	      % pname
-	      % ( "zypper in " + pname )
+	      % ( "zypper in -t patch" + pname )
 	      % "--with-optional" ).str();
     }
 

--- a/src/RequestFeedback.cc
+++ b/src/RequestFeedback.cc
@@ -180,7 +180,7 @@ std::string SolverRequester::Feedback::asUserString( const SolverRequester::Opti
       const std::string & pname( pIdent( _objsel ) );
       return( str::Format(_("Patch '%1%' is optional. Use '%2%' to install it, or '%3%' to include all optional patches."))
 	      % pname
-	      % ( "zypper in -t patch" + pname )
+	      % ( "zypper in patch:" + _objsel->name() )
 	      % "--with-optional" ).str();
     }
 


### PR DESCRIPTION
Add "-t patch" for optional patch in the warning message. If the user follow the current warning, he will get something like: 

sudo zypper in openSUSE-2016-1409-1
Loading repository data...
Reading installed packages...
'openSUSE-2016-1409-1' not found in package names. Trying capabilities.
No provider of 'openSUSE-2016-1409-1' found.

Proper way to install this patch:
sudo zypper in -t patch openSUSE-2016-1409-1
